### PR TITLE
add the ability to control colorization using an environment variable.

### DIFF
--- a/svn-color.sh
+++ b/svn-color.sh
@@ -23,7 +23,8 @@ function svn
 
 	# check if disabled
 	test "$CMDLEN" = "${#CMD}"
-	if [ $? = 1 ] || [ ! -t 1 ]
+	NOCOL=$?
+	if [ "$SVN_COLOR" != "always" ] && ( [ $NOCOL = 1 ] || [ "$SVN_COLOR" = "never" ] || [ ! -t 1 ] )
 	then
 		eval $(which svn) $CMD
 		return


### PR DESCRIPTION
the existing method of disabling colorization requires an incompatible
flag. further, it's not possible to force colorization on when e.g. capturing
output of svn.
